### PR TITLE
Removing not used TYK_DASHBOARD_DOMAIN variable

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -10,9 +10,6 @@
 
 # OSX users will need to specify a virtual IP, linux users can use 127.0.0.1
 
-# Proxy
-TYK_DASHBOARD_DOMAIN="tyk_dashboard"
-
 # Tyk dashboard settings
 TYK_DASHBOARD_USERNAME="test$RANDOM@test.com"
 TYK_DASHBOARD_PASSWORD="test123"


### PR DESCRIPTION
It was used in quick_start repo, but not used there. Probably just copy-paste issue.