### PR TITLE
Improve installation - ignore

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -15,11 +15,22 @@ TYK_DASHBOARD_USERNAME="test$RANDOM@test.com"
 TYK_DASHBOARD_PASSWORD="test123"
 
 # Tyk portal settings
-TYK_PORTAL_DOMAIN="www.tyk-portal-test.com"
-TYK_DASH_DOMAIN="www.tyk-test.com"
+TYK_PORTAL_DOMAIN="www.tyk-portal.com"
+TYK_DASH_DOMAIN="www.tyk-dashboard.com"
 TYK_PORTAL_PATH="/portal/"
+ADMIN_KEY="12345"
+ORG_NAME="TestOrg$RANDOM Ltd" 
 
 DOCKER_IP="127.0.0.1"
+
+function jsonKey {
+    sed -n "s/.*\"${1}\":\"\([^\"]*\)\".*/\1/p"
+}
+
+
+function jsonDashboardResponse {
+    sed -n "s/.*\"${1}\":\[\{.*\}\]/p"
+}
 
 if [ -n "$DOCKER_HOST" ]
 then
@@ -48,32 +59,104 @@ then
         echo "If this is wrong, please specify the instance IP address (e.g. ./setup.sh 192.168.1.1)"
 fi
 
-echo "Creating Organisation"
-ORG_DATA=$(curl --silent --header "admin-auth: 12345" --header "Content-Type:application/json" --data '{"owner_name": "TestOrg5 Ltd.","owner_slug": "testorg", "cname_enabled":true, "cname": "'$TYK_PORTAL_DOMAIN'"}' http://$DOCKER_IP:3000/admin/organisations 2>&1)
-ORG_ID=$(echo $ORG_DATA | python -c 'import json,sys;obj=json.load(sys.stdin);print obj["Meta"]')
-echo "ORG ID: $ORG_ID"
+ORGS_DATA=$(curl --silent --header "admin-auth: $ADMIN_KEY" --header "Content-Type:application/json" http://$DOCKER_IP:3000/admin/organisations 2>&1)
+echo "ORGS_DATA: $ORGS_DATA"
+HAS_ANOTHER_ORG=$(echo $ORGS_DATA |  python -c 'import json,sys;obj=json.load(sys.stdin);print obj["organisations"][0]["id"]')
+if [ -n "$HAS_ANOTHER_ORG" ]
+then
+	echo "You have another organisation defined in mongoDB, would you like to proceed or stop in order to drop the database and then run this script again? "
+	echo "Choose 'P' to add another oranisation or 'E' to exit $0 script"
+	read ANSWER
+	if [ $ANSWER = "P" ]
+	then 
+		echo "Will proceed with creating another organisation..."
+	else
+		echo "Running $0 script has stopped. Please drop the database and re-run this script"
+		exit 5
+	fi
+fi
 
-echo "Adding new user"
+echo "Creating an Organisation..."
+ORG_DATA=$(curl --silent --header "admin-auth: $ADMIN_KEY" --header "Content-Type:application/json" --data '{"owner_name": "TestOrg5 Ltd.","owner_slug": "testorg", "cname_enabled":true, "cname": "'$TYK_PORTAL_DOMAIN'"}' http://$DOCKER_IP:3000/admin/organisations 2>&1)
+echo "ORG_DATA= $ORG_DATA"
+STATUS_MESSAGE=$(echo $ORG_DATA | jsonKey "Status")
+if [ "$STATUS_MESSAGE" != "OK" ]
+then
+	ERROR_MESSAGE=$(echo $ORG_DATA | jsonKey "Message")
+
+	echo "The following error return from the API endpoint for creating an organisation: $ERROR_MESSAGE"
+
+	if [ "$ERROR_MESSAGE" = "Failed to save new Org object to DB" ] 
+	then
+		echo "Please check MongoDB is running."
+	fi
+	echo "Running $0 script has stopped."
+	exit 1
+fi
+ORG_ID=$(echo $ORG_DATA | jsonKey "Meta")
+if [ -z "$ORG_ID" ]
+then
+	echo "Stopping $0 script - API call hasn't returned the org_id"
+	exit 2
+fi	
+echo "    ORG ID: $ORG_ID"
+
+echo "Adding a new user..."
 USER_DATA=$(curl --silent --header "admin-auth: 12345" --header "Content-Type:application/json" --data '{"first_name": "John","last_name": "Smith","email_address": "'$TYK_DASHBOARD_USERNAME'","active": true,"org_id": "'$ORG_ID'"}' http://$DOCKER_IP:3000/admin/users 2>&1)
-USER_AUTH=$(echo $USER_DATA | python -c 'import json,sys;obj=json.load(sys.stdin);print obj["Message"]')
+STATUS_MESSAGE=$(echo $USER_DATA | jsonKey "Status")
+USER_AUTH=$(echo $USER_DATA | jsonKey "Message")
+echo "    USER_AUTH= $USER_AUTH"
+if [ "$STATUS_MESSAGE" != "OK" ]
+then
+	echo "The following error return from the API endpoint for creating a new user: $USER_AUTH"
+	echo "Running $0 script has stopped."
+	exit 3
+fi
 USER_LIST=$(curl --silent --header "authorization: $USER_AUTH" http://$DOCKER_IP:3000/api/users 2>&1)
+STATUS_MESSAGE=$(echo $USER_LIST | jsonKey "Status")
+if [ "$STATUS_MESSAGE" != "" ] && [ "$STATUS_MESSAGE" != "OK" ]
+then
+	ERROR_MESSAGE=$(echo $USER_LIST | jsonKey "Message")
+        echo "    The following error return from the API endpoint for getting the user details: $ERROR_MESSAGE"
+        echo "    Running $0 script has stopped."
+        exit 3
+fi
 USER_ID=$(echo $USER_LIST | python -c 'import json,sys;obj=json.load(sys.stdin);print obj["users"][0]["id"]')
-echo "USER AUTH: $USER_AUTH"
 echo "USER ID: $USER_ID"
-
+if [ -z $USER_ID ]
+then
+	echo "Failed to read the user we have just created"
+	echo "    Running $0 script has stopped."
+	exit 4
+fi
 echo "Setting password"
-OK=$(curl --silent --header "authorization: $USER_AUTH" --header "Content-Type:application/json" http://$DOCKER_IP:3000/api/users/$USER_ID/actions/reset --data '{"new_password":"'$TYK_DASHBOARD_PASSWORD'"}')
+RESET_PASSWORD=$(curl --silent --header "authorization: $USER_AUTH" --header "Content-Type:application/json" http://$DOCKER_IP:3000/api/users/$USER_ID/actions/reset --data '{"new_password":"'$TYK_DASHBOARD_PASSWORD'"}')
+STATUS_MESSAGE=$(echo $RESET_PASSWORD | jsonKey "Status")
+if [ "$STATUS_MESSAGE" != "" ] && [ "$STATUS_MESSAGE" != "OK" ]
+then
+        ERROR_MESSAGE=$(echo $RESET_PASSWORD | jsonKey "Message")
+        echo "    The following error was return by the API endpoint for reseting the user details: $ERROR_MESSAGE"
+        echo "    Running $0 script has stopped."
+        exit 3
+fi
 
 echo "Setting up the Portal catalogue"
 CATALOGUE_DATA=$(curl --silent --header "Authorization: $USER_AUTH" --header "Content-Type:application/json" --data '{"org_id": "'$ORG_ID'"}' http://$DOCKER_IP:3000/api/portal/catalogue 2>&1)
-CATALOGUE_ID=$(echo $CATALOGUE_DATA | python -c 'import json,sys;obj=json.load(sys.stdin);print obj["Message"]')
+CATALOGUE_STATUS=$(echo $CATALOGUE_DATA | jsonKey "Status")
+if [ "$CATALOGUE_STATUS" != "" ] && [ "$CATALOGUE_STATUS" != "OK" ]
+then
+	ERROR_MESSAGE=$(echo $CATALOGUE_DATA | jsonKey "Message")
+        echo "    The following error was return by the API endpoint for reseting the user details: $ERROR_MESSAGE"
+        echo "    Running $0 script has stopped."
+        exit 3
+fi
 OK=$(curl --silent --header "Authorization: $USER_AUTH" http://$DOCKER_IP:3000/api/portal/catalogue 2>&1)
 
 echo "Creating the Portal Home page"
 OK=$(curl --silent --header "Authorization: $USER_AUTH" --header "Content-Type:application/json" --data '{"is_homepage": true, "template_name":"", "title":"Tyk Developer Portal", "slug":"home", "fields": {"JumboCTATitle": "Tyk Developer Portal", "SubHeading": "Sub Header", "JumboCTALink": "#cta", "JumboCTALinkTitle": "Your awesome APIs, hosted with Tyk!", "PanelOneContent": "Panel 1 content.", "PanelOneLink": "#panel1", "PanelOneLinkTitle": "Panel 1 Button", "PanelOneTitle": "Panel 1 Title", "PanelThereeContent": "", "PanelThreeContent": "Panel 3 content.", "PanelThreeLink": "#panel3", "PanelThreeLinkTitle": "Panel 3 Button", "PanelThreeTitle": "Panel 3 Title", "PanelTwoContent": "Panel 2 content.", "PanelTwoLink": "#panel2", "PanelTwoLinkTitle": "Panel 2 Button", "PanelTwoTitle": "Panel 2 Title"}}' http://$DOCKER_IP:3000/api/portal/pages 2>&1)
 
 echo "Fixing Portal URL"
-URL_DATA=$(curl --silent --header "admin-auth: 12345" --header "Content-Type:application/json" http://$DOCKER_IP:3000/admin/system/reload 2>&1)
+URL_DATA=$(curl --silent --header "admin-auth: $ADMIN_KEY" --header "Content-Type:application/json" http://$DOCKER_IP:3000/admin/system/reload 2>&1)
 CAT_DATA=$(curl -X POST --silent --header "Authorization: $USER_AUTH" --header "Content-Type:application/json" --data "{}" http://$DOCKER_IP:3000/api/portal/configuration 2>&1)
 
 echo ""

--- a/setup.sh
+++ b/setup.sh
@@ -11,32 +11,29 @@
 # OSX users will need to specify a virtual IP, linux users can use 127.0.0.1
 
 # Tyk dashboard settings
-TYK_DASHBOARD_USERNAME="test$RANDOM@test.com"
+RANDOM_NAME=$RANDOM
+ORG_NAME="TestOrg$RANDOM_NAME"
+TYK_DASHBOARD_USERNAME="test$RANDOM_NAME@test.com"
 TYK_DASHBOARD_PASSWORD="test123"
 
 # Tyk portal settings
-TYK_PORTAL_DOMAIN="www.tyk-portal.com"
-TYK_DASH_DOMAIN="www.tyk-dashboard.com"
+TYK_PORTAL_DOMAIN="www.tyk-portal-test.com"
+TYK_DASH_DOMAIN="www.tyk-test.com"
 TYK_PORTAL_PATH="/portal/"
+
 ADMIN_KEY="12345"
-ORG_NAME="TestOrg$RANDOM Ltd" 
 
 DOCKER_IP="127.0.0.1"
 
 function jsonKey {
-    sed -n "s/.*\"${1}\":\"\([^\"]*\)\".*/\1/p"
-}
-
-
-function jsonDashboardResponse {
-    sed -n "s/.*\"${1}\":\[\{.*\}\]/p"
+	sed -n "s/.*\"${1}\":\"\([^\"]*\)\".*/\1/p"
 }
 
 if [ -n "$DOCKER_HOST" ]
 then
-		echo "Detected a Docker VM..."
-		REMTCP=${DOCKER_HOST#tcp://}
-		DOCKER_IP=${REMTCP%:*}
+	echo "Detected a Docker VM..."
+	REMTCP=${DOCKER_HOST#tcp://}
+	DOCKER_IP=${REMTCP%:*}
 fi
 
 if [ -n "$1" ]
@@ -55,30 +52,32 @@ fi
 
 if [ -z "$1" ]
 then
-        echo "Using $DOCKER_IP as Tyk host address."
-        echo "If this is wrong, please specify the instance IP address (e.g. ./setup.sh 192.168.1.1)"
+		echo "Using $DOCKER_IP as Tyk host address."
+		echo "If this is wrong, please specify the instance IP address (e.g. ./setup.sh 192.168.1.1)"
 fi
 
 ORGS_DATA=$(curl --silent --header "admin-auth: $ADMIN_KEY" --header "Content-Type:application/json" http://$DOCKER_IP:3000/admin/organisations 2>&1)
-echo "ORGS_DATA: $ORGS_DATA"
+
 HAS_ANOTHER_ORG=$(echo $ORGS_DATA |  python -c 'import json,sys;obj=json.load(sys.stdin);print obj["organisations"][0]["id"]')
 if [ -n "$HAS_ANOTHER_ORG" ]
 then
-	echo "You have another organisation defined in mongoDB, would you like to proceed or stop in order to drop the database and then run this script again? "
-	echo "Choose 'P' to add another oranisation or 'E' to exit $0 script"
-	read ANSWER
-	if [ $ANSWER = "P" ]
-	then 
-		echo "Will proceed with creating another organisation..."
-	else
-		echo "Running $0 script has stopped. Please drop the database and re-run this script"
-		exit 5
-	fi
+	echo "IMPORTANT: You have another organisation defined in mongoDB, would you like to proceed and add another organisation or stop in order to drop the database and then run this script again? (y/n)"
+	while true; do
+		read -n 1 -p "Please enter just y/n: " ANSWER
+			case $ANSWER in
+				y ) echo "Will proceed with creating another organisation..."; break
+			;;
+				n )  echo "Running $0 script has stopped. Please drop the database and re-run this script"; exit 1
+			;;
+			* )	  echo -e "\n $ANSWER is not y/n...   "
+			;;
+			esac
+	done
 fi
 
-echo "Creating an Organisation..."
-ORG_DATA=$(curl --silent --header "admin-auth: $ADMIN_KEY" --header "Content-Type:application/json" --data '{"owner_name": "TestOrg5 Ltd.","owner_slug": "testorg", "cname_enabled":true, "cname": "'$TYK_PORTAL_DOMAIN'"}' http://$DOCKER_IP:3000/admin/organisations 2>&1)
-echo "ORG_DATA= $ORG_DATA"
+echo -e "\nCreating '$ORG_NAME' organisation..."
+ORG_DATA=$(curl --silent --header "admin-auth: $ADMIN_KEY" --header "Content-Type:application/json" --data '{"owner_name": "'$ORG_NAME' Ltd","owner_slug": "testorg", "cname_enabled":true, "cname": "'$TYK_PORTAL_DOMAIN'"}' http://$DOCKER_IP:3000/admin/organisations 2>&1)
+
 STATUS_MESSAGE=$(echo $ORG_DATA | jsonKey "Status")
 if [ "$STATUS_MESSAGE" != "OK" ]
 then
@@ -86,76 +85,88 @@ then
 
 	echo "The following error return from the API endpoint for creating an organisation: $ERROR_MESSAGE"
 
-	if [ "$ERROR_MESSAGE" = "Failed to save new Org object to DB" ] 
+	if [ "$ERROR_MESSAGE" = "Failed to save new Org object to DB" ]
+
 	then
 		echo "Please check MongoDB is running."
 	fi
 	echo "Running $0 script has stopped."
-	exit 1
+	exit 2
 fi
 ORG_ID=$(echo $ORG_DATA | jsonKey "Meta")
 if [ -z "$ORG_ID" ]
 then
 	echo "Stopping $0 script - API call hasn't returned the org_id"
-	exit 2
-fi	
-echo "    ORG ID: $ORG_ID"
+	exit 3
+fi
+echo "	ORG ID $ORG_ID"
 
-echo "Adding a new user..."
+echo  -e "\nAdding a new user..."
+echo "	Creating user for email: $TYK_DASHBOARD_USERNAME"
 USER_DATA=$(curl --silent --header "admin-auth: 12345" --header "Content-Type:application/json" --data '{"first_name": "John","last_name": "Smith","email_address": "'$TYK_DASHBOARD_USERNAME'","active": true,"org_id": "'$ORG_ID'"}' http://$DOCKER_IP:3000/admin/users 2>&1)
 STATUS_MESSAGE=$(echo $USER_DATA | jsonKey "Status")
 USER_AUTH=$(echo $USER_DATA | jsonKey "Message")
-echo "    USER_AUTH= $USER_AUTH"
+echo "	User authentication key: $USER_AUTH"
 if [ "$STATUS_MESSAGE" != "OK" ]
 then
 	echo "The following error return from the API endpoint for creating a new user: $USER_AUTH"
 	echo "Running $0 script has stopped."
-	exit 3
+	exit 4
 fi
+
 USER_LIST=$(curl --silent --header "authorization: $USER_AUTH" http://$DOCKER_IP:3000/api/users 2>&1)
 STATUS_MESSAGE=$(echo $USER_LIST | jsonKey "Status")
 if [ "$STATUS_MESSAGE" != "" ] && [ "$STATUS_MESSAGE" != "OK" ]
 then
 	ERROR_MESSAGE=$(echo $USER_LIST | jsonKey "Message")
-        echo "    The following error return from the API endpoint for getting the user details: $ERROR_MESSAGE"
-        echo "    Running $0 script has stopped."
-        exit 3
+		echo "	The following error return from the API endpoint for getting the user details: $ERROR_MESSAGE"
+		echo "	Running $0 script has stopped."
+		exit 5
 fi
+
 USER_ID=$(echo $USER_LIST | python -c 'import json,sys;obj=json.load(sys.stdin);print obj["users"][0]["id"]')
-echo "USER ID: $USER_ID"
 if [ -z $USER_ID ]
 then
 	echo "Failed to read the user we have just created"
-	echo "    Running $0 script has stopped."
-	exit 4
+	echo "	Running $0 script has stopped."
+	exit 6
 fi
-echo "Setting password"
+USER_EMAIL=$(echo $USER_LIST | python -c 'import json,sys;obj=json.load(sys.stdin);print obj["users"][0]["email_address"]')
+if [ $USER_EMAIL != $TYK_DASHBOARD_USERNAME ]
+then
+	echo "	Error occurred: Posted user $TYK_DASHBOARD_USERNAME is not equal to the created user $USER_EMAIL."
+	echo "	Running $0 script has stopped."
+	exit 7
+fi
+echo "	User ID: $USER_ID"
+echo "	Setting password for user $USER_EMAIL"
 RESET_PASSWORD=$(curl --silent --header "authorization: $USER_AUTH" --header "Content-Type:application/json" http://$DOCKER_IP:3000/api/users/$USER_ID/actions/reset --data '{"new_password":"'$TYK_DASHBOARD_PASSWORD'"}')
 STATUS_MESSAGE=$(echo $RESET_PASSWORD | jsonKey "Status")
 if [ "$STATUS_MESSAGE" != "" ] && [ "$STATUS_MESSAGE" != "OK" ]
 then
-        ERROR_MESSAGE=$(echo $RESET_PASSWORD | jsonKey "Message")
-        echo "    The following error was return by the API endpoint for reseting the user details: $ERROR_MESSAGE"
-        echo "    Running $0 script has stopped."
-        exit 3
+		ERROR_MESSAGE=$(echo $RESET_PASSWORD | jsonKey "Message")
+		echo "	The following error was return by the API endpoint for reseting the user details: $ERROR_MESSAGE"
+		echo "	Running $0 script has stopped."
+		exit 8
 fi
 
-echo "Setting up the Portal catalogue"
+echo -e "\nDeveloper Portal"
+echo "	Setting up the Portal catalogue..."
 CATALOGUE_DATA=$(curl --silent --header "Authorization: $USER_AUTH" --header "Content-Type:application/json" --data '{"org_id": "'$ORG_ID'"}' http://$DOCKER_IP:3000/api/portal/catalogue 2>&1)
 CATALOGUE_STATUS=$(echo $CATALOGUE_DATA | jsonKey "Status")
 if [ "$CATALOGUE_STATUS" != "" ] && [ "$CATALOGUE_STATUS" != "OK" ]
 then
 	ERROR_MESSAGE=$(echo $CATALOGUE_DATA | jsonKey "Message")
-        echo "    The following error was return by the API endpoint for reseting the user details: $ERROR_MESSAGE"
-        echo "    Running $0 script has stopped."
-        exit 3
+		echo "	The following error was return by the API endpoint for reseting the user details: $ERROR_MESSAGE"
+		echo "	Running $0 script has stopped."
+		exit 9
 fi
 OK=$(curl --silent --header "Authorization: $USER_AUTH" http://$DOCKER_IP:3000/api/portal/catalogue 2>&1)
 
-echo "Creating the Portal Home page"
+echo "	Creating the Portal Home page..."
 OK=$(curl --silent --header "Authorization: $USER_AUTH" --header "Content-Type:application/json" --data '{"is_homepage": true, "template_name":"", "title":"Tyk Developer Portal", "slug":"home", "fields": {"JumboCTATitle": "Tyk Developer Portal", "SubHeading": "Sub Header", "JumboCTALink": "#cta", "JumboCTALinkTitle": "Your awesome APIs, hosted with Tyk!", "PanelOneContent": "Panel 1 content.", "PanelOneLink": "#panel1", "PanelOneLinkTitle": "Panel 1 Button", "PanelOneTitle": "Panel 1 Title", "PanelThereeContent": "", "PanelThreeContent": "Panel 3 content.", "PanelThreeLink": "#panel3", "PanelThreeLinkTitle": "Panel 3 Button", "PanelThreeTitle": "Panel 3 Title", "PanelTwoContent": "Panel 2 content.", "PanelTwoLink": "#panel2", "PanelTwoLinkTitle": "Panel 2 Button", "PanelTwoTitle": "Panel 2 Title"}}' http://$DOCKER_IP:3000/api/portal/pages 2>&1)
 
-echo "Fixing Portal URL"
+echo "	Fixing Portal URL..."
 URL_DATA=$(curl --silent --header "admin-auth: $ADMIN_KEY" --header "Content-Type:application/json" http://$DOCKER_IP:3000/admin/system/reload 2>&1)
 CAT_DATA=$(curl -X POST --silent --header "Authorization: $USER_AUTH" --header "Content-Type:application/json" --data "{}" http://$DOCKER_IP:3000/api/portal/configuration 2>&1)
 
@@ -163,8 +174,9 @@ echo ""
 
 echo "DONE"
 echo "===="
-echo "Login at http://$TYK_DASH_DOMAIN:3000/"
-echo "Username: $TYK_DASHBOARD_USERNAME"
+echo "Organisation: $ORG_NAME, ID: $ORG_ID"
+echo "Dashboard Login at http://$TYK_DASH_DOMAIN:3000/"
+echo "Username: $USER_EMAIL"
 echo "Password: $TYK_DASHBOARD_PASSWORD"
-echo "Portal: http://$TYK_PORTAL_DOMAIN:3000$TYK_PORTAL_PATH"
+echo "Developer Portal Login at: http://$TYK_PORTAL_DOMAIN:3000$TYK_PORTAL_PATH"
 echo ""


### PR DESCRIPTION
A quick fix for the bootstrap till I get the chance to write a cli.

1.  If there's already an org in mongo - asking to exit or proceed. Can only proceed with capital 'P'
2. Organisation's name has the same random number as the user. This way multiple orgs will not share the same name and when users log in they will actually be able to see it.
3. If the api call returns an 'Error' or empty string - we exit with a message
4. Using jsonKey function instead of python to query the dashboards returned data.
5. Tidy up the output with some silly but clearer indentations.
