### PR TITLE
optimise default configs

### DIFF
--- a/confs/tyk.conf
+++ b/confs/tyk.conf
@@ -1,165 +1,167 @@
 {
-    "listen_address": "",
-    "listen_port": 8181,
-    "secret": "352d20ee67be67f6340b4c0605b044b7",
-    "node_secret": "352d20ee67be67f6340b4c0605b044b7",
-    "template_path": "./templates",
-    "tyk_js_path": "./js/tyk.js",
-    "middleware_path": "./middleware",
-    "policies": {
-        "policy_source": "service",
-        "policy_connection_string": "http://tyk-dashboard:3000",
-        "policy_record_name": "tyk_policies",
-        "allow_explicit_policy_id": true
+  "listen_address": "",
+  "listen_port": 8181,
+  "secret": "352d20ee67be67f6340b4c0605b044b7",
+  "node_secret": "352d20ee67be67f6340b4c0605b044b7",
+  "template_path": "./templates",
+  "tyk_js_path": "./js/tyk.js",
+  "middleware_path": "./middleware",
+  "policies": {
+    "policy_source": "service",
+    "policy_connection_string": "http://tyk-dashboard:3000",
+    "policy_record_name": "tyk_policies",
+    "allow_explicit_policy_id": true
+  },
+  "use_db_app_configs": true,
+  "db_app_conf_options": {
+    "connection_string": "http://tyk-dashboard:3000",
+    "node_is_segmented": false,
+    "tags": [
+      "test"
+    ]
+  },
+  "disable_dashboard_zeroconf": false,
+  "app_path": "./test_apps/",
+  "storage": {
+    "type": "redis",
+    "host": "tyk-redis",
+    "port": 6379,
+    "hosts": null,
+    "username": "",
+    "password": "",
+    "database": 0,
+    "optimisation_max_idle": 3000,
+    "optimisation_max_active": 5000,
+    "enable_cluster": false
+  },
+  "enable_separate_cache_store": false,
+  "enable_analytics": true,
+  "analytics_config": {
+    "type": "mongo",
+    "ignored_ips": [],
+    "enable_detailed_recording": false,
+    "enable_geo_ip": false,
+    "geo_ip_db_path": "./GeoLite2-City.mmdb",
+    "normalise_urls": {
+      "enabled": true,
+      "normalise_uuids": true,
+      "normalise_numbers": true,
+      "custom_patterns": []
+    }
+  },
+  "health_check": {
+    "enable_health_checks": false,
+    "health_check_value_timeouts": 0
+  },
+  "optimisations_use_async_session_write": true,
+  "allow_master_keys": false,
+  "hash_keys": true,
+  "suppress_redis_signal_reload": false,
+  "suppress_default_org_store": false,
+  "use_redis_log": true,
+  "sentry_code": "",
+  "use_sentry": false,
+  "use_syslog": false,
+  "use_graylog": false,
+  "use_logstash": false,
+  "graylog_network_addr": "",
+  "logstash_network_addr": "",
+  "syslog_transport": "",
+  "logstash_transport": "",
+  "syslog_network_addr": "",
+  "enforce_org_data_age": true,
+  "enforce_org_data_detail_logging": false,
+  "enforce_org_quotas": true,
+  "experimental_process_org_off_thread": false,
+  "enable_non_transactional_rate_limiter": true,
+  "enable_sentinel_rate_limiter": false,
+  "Monitor": {
+    "enable_trigger_monitors": false,
+    "configuration": {
+      "method": "",
+      "target_path": "",
+      "template_path": "",
+      "header_map": null,
+      "event_timeout": 0
     },
-    "use_db_app_configs": true,
-    "db_app_conf_options": {
-        "connection_string": "http://tyk-dashboard:3000",
-        "node_is_segmented": false,
-        "tags": ["test"]
+    "global_trigger_limit": 0,
+    "monitor_user_keys": false,
+    "monitor_org_keys": false
+  },
+  "oauth_refresh_token_expire": 0,
+  "oauth_token_expire": 0,
+  "oauth_redirect_uri_separator": ";",
+  "slave_options": {
+    "use_rpc": false,
+    "connection_string": "",
+    "rpc_key": "",
+    "api_key": "",
+    "enable_rpc_cache": false,
+    "bind_to_slugs": false,
+    "disable_keyspace_sync": false,
+    "group_id": ""
+  },
+  "disable_virtual_path_blobs": false,
+  "local_session_cache": {
+    "disable_cached_session_state": true,
+    "cached_session_timeout": 0,
+    "cached_session_eviction": 0
+  },
+  "http_server_options": {
+    "override_defaults": false,
+    "read_timeout": 0,
+    "write_timeout": 0,
+    "use_ssl": false,
+    "use_ssl_le": false,
+    "enable_websockets": true,
+    "certificates": [],
+    "server_name": "",
+    "min_version": 0,
+    "flush_interval": 0
+  },
+  "service_discovery": {
+    "default_cache_timeout": 0
+  },
+  "close_connections": false,
+  "auth_override": {
+    "force_auth_provider": false,
+    "auth_provider": {
+      "name": "",
+      "storage_engine": "",
+      "meta": null
     },
-    "disable_dashboard_zeroconf": false,
-    "app_path": "./test_apps/",
-    "storage": {
-        "type": "redis",
-        "host": "tyk-redis",
-        "port": 6379,
-        "hosts": null,
-        "username": "",
-        "password": "",
-        "database": 0,
-        "optimisation_max_idle": 3000,
-        "optimisation_max_active": 5000,
-        "enable_cluster": false
-    },
-    "enable_separate_cache_store": false,
-    "enable_analytics": true,
-    "analytics_config": {
-        "type": "mongo",
-        "ignored_ips": [],
-        "enable_detailed_recording": false,
-        "enable_geo_ip": false,
-        "geo_ip_db_path": "./GeoLite2-City.mmdb",
-        "normalise_urls": {
-            "enabled": true,
-            "normalise_uuids": true,
-            "normalise_numbers": true,
-            "custom_patterns": []
-        }
-    },
-    "health_check": {
-        "enable_health_checks": false,
-        "health_check_value_timeouts": 0
-    },
-    "optimisations_use_async_session_write": true,
-    "allow_master_keys": false,
-    "hash_keys": true,
-    "suppress_redis_signal_reload": false,
-    "suppress_default_org_store": false,
-    "use_redis_log": true,
-    "sentry_code": "",
-    "use_sentry": false,
-    "use_syslog": false,
-    "use_graylog": false,
-    "use_logstash": false,
-    "graylog_network_addr": "",
-    "logstash_network_addr": "",
-    "syslog_transport": "",
-    "logstash_transport": "",
-    "syslog_network_addr": "",
-    "enforce_org_data_age": true,
-    "enforce_org_data_detail_logging": false,
-    "enforce_org_quotas": true,
-    "experimental_process_org_off_thread": false,
-    "enable_non_transactional_rate_limiter": true,
-    "enable_sentinel_rate_limiter": false,
-    "Monitor": {
-        "enable_trigger_monitors": false,
-        "configuration": {
-            "method": "",
-            "target_path": "",
-            "template_path": "",
-            "header_map": null,
-            "event_timeout": 0
-        },
-        "global_trigger_limit": 0,
-        "monitor_user_keys": false,
-        "monitor_org_keys": false
-    },
-    "oauth_refresh_token_expire": 0,
-    "oauth_token_expire": 0,
-    "oauth_redirect_uri_separator": ";",
-    "slave_options": {
-        "use_rpc": false,
-        "connection_string": "",
-        "rpc_key": "",
-        "api_key": "",
-        "enable_rpc_cache": false,
-        "bind_to_slugs": false,
-        "disable_keyspace_sync": false,
-        "group_id": ""
-    },
-    "disable_virtual_path_blobs": false,
-    "local_session_cache": {
-        "disable_cached_session_state": true,
-        "cached_session_timeout": 0,
-        "cached_session_eviction": 0
-    },
-    "http_server_options": {
-        "override_defaults": false,
-        "read_timeout": 0,
-        "write_timeout": 0,
-        "use_ssl": false,
-        "use_ssl_le": false,
-        "enable_websockets": true,
-        "certificates": [],
-        "server_name": "",
-        "min_version": 0,
-        "flush_interval": 0
-    },
-    "service_discovery": {
-        "default_cache_timeout": 0
-    },
-    "close_connections": true,
-    "auth_override": {
-        "force_auth_provider": false,
-        "auth_provider": {
-            "name": "",
-            "storage_engine": "",
-            "meta": null
-        },
-        "force_session_provider": false,
-        "session_provider": {
-            "name": "",
-            "storage_engine": "",
-            "meta": null
-        }
-    },
-    "uptime_tests": {
-        "disable": true,
-        "config": {
-            "failure_trigger_sample_size": 1,
-            "time_wait": 2,
-            "checker_pool_size": 50,
-            "enable_uptime_analytics": true
-        }
-    },
-    "hostname": "",
-    "enable_api_segregation": false,
-    "control_api_hostname": "",
-    "enable_custom_domains": true,
-    "enable_jsvm": true,
-    "enable_coprocess": false,
-    "hide_generator_header": false,
-    "event_handlers": {
-        "events": {}
-    },
-    "event_trigers_defunct": {},
-    "pid_file_location": "./tyk-gateway.pid",
-    "allow_insecure_configs": true,
-    "public_key_path": "",
-    "close_idle_connections": false,
-    "allow_remote_config": true,
-    "enable_bundle_downloader": false
+    "force_session_provider": false,
+    "session_provider": {
+      "name": "",
+      "storage_engine": "",
+      "meta": null
+    }
+  },
+  "uptime_tests": {
+    "disable": true,
+    "config": {
+      "failure_trigger_sample_size": 1,
+      "time_wait": 2,
+      "checker_pool_size": 50,
+      "enable_uptime_analytics": true
+    }
+  },
+  "hostname": "",
+  "enable_api_segregation": false,
+  "control_api_hostname": "",
+  "enable_custom_domains": true,
+  "enable_jsvm": true,
+  "enable_coprocess": false,
+  "hide_generator_header": false,
+  "event_handlers": {
+    "events": {}
+  },
+  "event_trigers_defunct": {},
+  "pid_file_location": "./tyk-gateway.pid",
+  "allow_insecure_configs": true,
+  "public_key_path": "",
+  "close_idle_connections": false,
+  "allow_remote_config": true,
+  "enable_bundle_downloader": false,
+  "max_idle_connections_per_host": 500
 }
-    


### PR DESCRIPTION
Fixes #12

Ensure `"max_idle_connections_per_host": 500` where previously was
capped at 100.
Ensure `"close_connections":false` is the default.