### PR TITLE
Update listening ports to allow for MacOS Monterey now using port 5000

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: tykio/tyk-dashboard:v3.2.2
     ports:
     - "3000:3000"
-    - "5000:5000"
+    - "6000:6000"
     env_file:
     - ./confs/tyk_analytics.env
     networks:


### PR DESCRIPTION
It looks like macOS Monterey now binds 'Control Center' to port 5000:
https://developer.apple.com/forums/thread/682332

This leads to 'Error response from daemon: Ports are not available: listen tcp 0.0.0.0:5000: bind: address already in use' errors when you try to start up.

The fix seems to be as simple as changing the two instances of 5000 to be 6000 in docker-compose.yml.

I made this change and then everything ran fine. Although I did need to put in place the workaround for Apple M1 chips described here for my testing: https://github.com/TykTechnologies/tyk-pro-docker-demo/issues/32 (i.e. set the Mongo version to be 4.0 in the docker-compose.yml file). I haven't put that into this pull request because I don't know if pushing everyone to Mongo v4 is safe to do.

closes #33 