### PR TITLE
Remove port 5000

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,6 @@ services:
     image: tykio/tyk-dashboard:v3.2.2
     ports:
     - "3000:3000"
-    - "6000:6000"
     env_file:
     - ./confs/tyk_analytics.env
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: tykio/tyk-dashboard:v3.2.2
     ports:
     - "3000:3000"
-    - "5000:5000"
+    - "6000:6000"
     env_file:
     - ./confs/tyk_analytics.env
     networks:


### PR DESCRIPTION
It looks like macOS Monterey now binds 'Control Center' to port 5000:
https://developer.apple.com/forums/thread/682332

This leads to 'Error response from daemon: Ports are not available: listen tcp 0.0.0.0:5000: bind: address already in use' errors when you try to start up.

Apparently the port 5000 usage in this demo isn't needed any more so I'm removing it to avoid this issue.

I made this change and then I could start the system and log into the dashboard fine. Although I did need to put in place the workaround for Apple chips, described here, for my testing: #32 (i.e. set the Mongo version to be 4.0 in the docker-compose.yml file). I haven't put that into this pull request because I don't know if pushing everyone to Mongo v4 is safe to do.

I haven't done any more testing beyond this though, so if this isn't sufficient to prove port 5000 is no longer needed, please let me know.

closes #33