### PR TITLE
added mongo environment variable for backwards compatibility

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     environment:
       - TYK_DB_STORAGE_MAIN_TYPE=mongo
       - TYK_DB_STORAGE_MAIN_CONNECTIONSTRING=mongodb://tyk-mongo:27017/tyk_analytics
+      # Mongodb connection string env variable used for versions older than 4.x.x.
       # - TYK_DB_MONGOURL=mongodb://tyk-mongo:27017/tyk_analytics
     ports:
       - "3000:3000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     environment:
       - TYK_DB_STORAGE_MAIN_TYPE=mongo
       - TYK_DB_STORAGE_MAIN_CONNECTIONSTRING=mongodb://tyk-mongo:27017/tyk_analytics
+      # - TYK_DB_MONGOURL=mongodb://tyk-mongo:27017/tyk_analytics
     ports:
       - "3000:3000"
     env_file:


### PR DESCRIPTION
Added the required tyk-dashboard environment variable for mongo. In order to get previous versions such as v3.0.9 in my case to work this variable was missing and was set to default/localhost. @zalbiraw @sedkis 