### PR TITLE
Added Healthcheck to docker-compose for postgres

### DIFF
--- a/confs/pump.postgres.env
+++ b/confs/pump.postgres.env
@@ -1,11 +1,11 @@
 TYK_PMP_PUMPS_MAIN_TYPE=SQL
 TYK_PMP_PUMPS_MAIN_META_TYPE=postgres
-TYK_PMP_PUMPS_MAIN_META_CONNECTIONSTRING=user=default password=topsecretpassword host=tyk-postgres port=5432 database=tyk_analytics
+TYK_PMP_PUMPS_MAIN_META_CONNECTIONSTRING=user=postgres password=topsecretpassword host=tyk-postgres port=5432 database=tyk_analytics
 
 TYK_PMP_PUMPS_MAINAGG_TYPE=sql_aggregate
 TYK_PMP_PUMPS_MAINAGG_META_TYPE=postgres
-TYK_PMP_PUMPS_MAINAGG_META_CONNECTIONSTRING=user=default password=topsecretpassword host=tyk-postgres port=5432 database=tyk_analytics
+TYK_PMP_PUMPS_MAINAGG_META_CONNECTIONSTRING=user=postgres password=topsecretpassword host=tyk-postgres port=5432 database=tyk_analytics
 
 TYK_PMP_UPTIMEPUMPCONFIG_UPTIMETYPE=sql
 TYK_PMP_UPTIMEPUMPCONFIG_TYPE=postgres
-TYK_PMP_UPTIMEPUMPCONFIG_CONNECTIONSTRING=user=default password=topsecretpassword host=tyk-postgres port=5432 database=tyk_analytics
+TYK_PMP_UPTIMEPUMPCONFIG_CONNECTIONSTRING=user=postgres password=topsecretpassword host=tyk-postgres port=5432 database=tyk_analytics

--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -3,11 +3,17 @@ services:
   tyk-dashboard:
     environment:
       - TYK_DB_STORAGE_MAIN_TYPE=postgres
-      - TYK_DB_STORAGE_MAIN_CONNECTIONSTRING=user=default password=topsecretpassword host=tyk-postgres port=5432 database=tyk_analytics
+      - TYK_DB_STORAGE_MAIN_CONNECTIONSTRING=user=postgres password=topsecretpassword host=tyk-postgres port=5432 database=tyk_analytics
+    depends_on:
+      tyk-postgres:
+        condition: service_healthy
 
   tyk-pump:
     env_file:
       - ./confs/pump.postgres.env
+    depends_on:
+      tyk-postgres:
+        condition: service_healthy
       
   tyk-postgres:
     image: postgres:latest
@@ -15,7 +21,7 @@ services:
 
     environment:
       - POSTGRES_DB=tyk_analytics
-      - POSTGRES_USER=default
+      - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=topsecretpassword
 
     ports:
@@ -23,6 +29,12 @@ services:
 
     volumes:
       - db-data:/data/db
+
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
     networks:
       - tyk


### PR DESCRIPTION
To resolve an issue whereby Postgres was too slow to startup, resulting in Tyk-Dashboard and Tyk-Pump exiting, have introduced a postgres healthcheck and Dashboard/Pump dependencies in docker-compose.

Also, changed the postgres user from `default` to `postgres` to resolve the fatal error: `FATAL:  role "postgres" does not exist`