### PR TITLE
Fixes issue with invalid postgres volume

### DIFF
--- a/docker-compose.mongo.yml
+++ b/docker-compose.mongo.yml
@@ -22,3 +22,6 @@ services:
 
     networks:
       - tyk
+
+volumes:
+  db-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ services:
       - "5432:5432"
 
     volumes:
-      - db-data:/data/db
+      - postgres-data:/var/lib/postgresql/data
 
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
@@ -75,7 +75,7 @@ services:
   
 volumes:
   redis-data:
-  db-data:
+  postgres-data:
 
 networks:
   tyk:


### PR DESCRIPTION
Resolves [this issue](https://github.com/TykTechnologies/tyk-pro-docker-demo/issues/47) whereby if the stack is restarted using `docker compose down` followed by `docker compose up`, the user is forced to bootstrap again, which means any APIs, policies etc previously configured are lost.

The issue was due to the postgres volume being copied from mongo, which is invalid.  Fixed to create new postgres volume `/var/lib/postgresql/data` 

Tested by running this for both postgres and mongo based stacks